### PR TITLE
fix: compact single-row heartbeat heatmap

### DIFF
--- a/src/pages/Heartbeats.jsx
+++ b/src/pages/Heartbeats.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo } from "react";
+import React, { useState, useEffect, useMemo, useRef } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { getRituals, detectHeartbeatGroups, formatRitualsData, formatString, formatTimeToText, getTimeout, getLiveRitualIds } from "./data";
 import styles from "./Heartbeats.module.css";
@@ -52,57 +52,57 @@ const Heartbeats = () => {
     return d.toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
   };
 
-  // Build heatmap data — daily heartbeat counts for last 52 weeks
-  const heatmapData = useMemo(() => {
-    const dayMap = {};
+  // Build weekly heatmap — one square per week, 52 weeks
+  const weeklyData = useMemo(() => {
+    // Bucket heartbeats by ISO week start (Monday)
+    const weekMap = {};
     allHeartbeats.forEach(r => {
       const ts = r.initTimeStamp || r.startedAt;
       if (!ts) return;
       const d = new Date(ts);
-      const key = d.toISOString().split('T')[0];
-      if (!dayMap[key]) dayMap[key] = { total: 0, successful: 0, failed: 0 };
-      dayMap[key].total++;
-      if (r.status === "SUCCESSFUL" || r.status === "ACTIVE") dayMap[key].successful++;
-      else dayMap[key].failed++;
+      const day = d.getDay();
+      const monday = new Date(d);
+      monday.setDate(d.getDate() - ((day + 6) % 7));
+      const key = monday.toISOString().split('T')[0];
+      if (!weekMap[key]) weekMap[key] = { total: 0, successful: 0, failed: 0 };
+      weekMap[key].total++;
+      if (r.status === "SUCCESSFUL" || r.status === "ACTIVE") weekMap[key].successful++;
+      else weekMap[key].failed++;
     });
 
-    // Generate 52 weeks of days ending today
     const today = new Date();
     today.setHours(0, 0, 0, 0);
-    const days = [];
-    // Start from the Sunday 52 weeks ago
     const start = new Date(today);
-    start.setDate(start.getDate() - start.getDay() - 52 * 7);
-    for (let d = new Date(start); d <= today; d.setDate(d.getDate() + 1)) {
+    start.setDate(start.getDate() - ((start.getDay() + 6) % 7) - 51 * 7);
+    const weeks = [];
+    for (let d = new Date(start); d <= today; d.setDate(d.getDate() + 7)) {
       const key = d.toISOString().split('T')[0];
-      days.push({ date: key, ...( dayMap[key] || { total: 0, successful: 0, failed: 0 }) });
+      weeks.push({ week: key, ...(weekMap[key] || { total: 0, successful: 0, failed: 0 }) });
     }
-    return days;
+    return weeks;
   }, [allHeartbeats]);
 
-  const maxCount = useMemo(() => Math.max(1, ...heatmapData.map(d => d.total)), [heatmapData]);
+  const maxCount = useMemo(() => Math.max(1, ...weeklyData.map(w => w.total)), [weeklyData]);
 
   const getHeatColor = (count, failed) => {
     if (count === 0) return 'var(--bg-tertiary)';
     if (failed > 0) {
       const ratio = failed / count;
-      if (ratio > 0.5) return '#FCA5A5';
-      if (ratio > 0.2) return '#FBBF24';
+      if (ratio > 0.5) return '#dc2626';
+      if (ratio > 0.2) return '#f59e0b';
     }
     const intensity = Math.min(count / maxCount, 1);
-    if (intensity < 0.25) return '#1A3D2A';
-    if (intensity < 0.5) return '#1F5C3A';
-    if (intensity < 0.75) return '#1A8048';
-    return '#059669';
+    if (intensity < 0.25) return '#86efac';
+    if (intensity < 0.5) return '#4ade80';
+    if (intensity < 0.75) return '#22c55e';
+    return '#16a34a';
   };
 
   if (loading) return <ListSkeleton cols={4} rows={8} />;
 
-  // Group heatmap into weeks (columns)
-  const weeks = [];
-  for (let i = 0; i < heatmapData.length; i += 7) {
-    weeks.push(heatmapData.slice(i, i + 7));
-  }
+  const SQ = 6, GAP = 2, STRIDE = SQ + GAP;
+  const svgW = weeklyData.length * STRIDE - GAP;
+  const svgH = SQ;
 
   return (
     <div className={styles.networkActivity}>
@@ -118,33 +118,40 @@ const Heartbeats = () => {
           ]}
         />
 
-        {/* Heartbeat Heatmap */}
+        {/* Heartbeat Heatmap — compact SVG */}
         <div className={styles.heatmapSection}>
-          <h3 style={{ fontSize: '13px', fontWeight: 600, marginBottom: '8px', color: 'var(--text-secondary)' }}>
-            HEARTBEAT ACTIVITY — LAST 52 WEEKS
-          </h3>
-          <div className={styles.heatmapLegend}>
-            <span style={{ fontSize: '11px', color: 'var(--text-tertiary)' }}>Less</span>
-            {['#222240', '#1A3D2A', '#1F5C3A', '#1A8048', '#059669'].map((c, i) => (
-              <div key={i} style={{ width: 10, height: 10, background: c, borderRadius: 1 }} />
-            ))}
-            <span style={{ fontSize: '11px', color: 'var(--text-tertiary)' }}>More</span>
-            <div style={{ width: 10, height: 10, background: '#FCA5A5', borderRadius: 1, marginLeft: 8 }} />
-            <span style={{ fontSize: '11px', color: 'var(--text-tertiary)' }}>Failures</span>
+          <div className={styles.heatmapHeader}>
+            <span className={styles.heatmapTitle}>Heartbeat activity — last 52 weeks</span>
+            <div className={styles.heatmapLegend}>
+              {[['#22c55e','Successful'],['#f59e0b','Partial'],['#dc2626','Failed']].map(([color, label]) => (
+                <span key={label} className={styles.legendItem}>
+                  <svg width={7} height={7} style={{ flexShrink: 0 }}>
+                    <rect width={7} height={7} rx={1} fill={color} opacity={0.85} />
+                  </svg>
+                  {label}
+                </span>
+              ))}
+              <span className={styles.legendRight}>← older · newer →</span>
+            </div>
           </div>
-          <div className={styles.heatmapGrid}>
-            {weeks.map((week, wi) => (
-              <div key={wi} className={styles.heatmapCol}>
-                {week.map((day, di) => (
-                  <div
-                    key={di}
-                    className={styles.heatmapCell}
-                    style={{ background: getHeatColor(day.total, day.failed) }}
-                    title={`${day.date}: ${day.total} heartbeats (${day.successful} ok, ${day.failed} failed)`}
-                  />
-                ))}
-              </div>
-            ))}
+          <div className={styles.heatmapSvgWrap}>
+            <svg width="100%" height={svgH} viewBox={`0 0 ${svgW} ${svgH}`}
+              preserveAspectRatio="xMinYMid meet" style={{ display: 'block' }}>
+              {weeklyData.map((w, i) => (
+                <rect
+                  key={i}
+                  x={i * STRIDE}
+                  y={0}
+                  width={SQ}
+                  height={SQ}
+                  rx={1}
+                  fill={getHeatColor(w.total, w.failed)}
+                  opacity={w.total === 0 ? 0.3 : 0.85}
+                >
+                  <title>Week of {w.week}: {w.total} heartbeats ({w.successful} ok, {w.failed} failed)</title>
+                </rect>
+              ))}
+            </svg>
           </div>
         </div>
 

--- a/src/pages/Heartbeats.module.css
+++ b/src/pages/Heartbeats.module.css
@@ -454,46 +454,52 @@
   font-family: var(--font-mono, 'Space Mono', monospace);
 }
 
-/* Heartbeat Heatmap */
+/* Heartbeat Heatmap — compact SVG */
 .heatmapSection {
-  background: var(--bg-primary);
+  background: var(--bg-surface);
   border: 1px solid var(--border-color);
   border-radius: 6px;
-  padding: 12px 16px;
+  padding: 10px 14px;
   margin-bottom: 16px;
 }
 
-.heatmapGrid {
+.heatmapHeader {
   display: flex;
-  gap: 3px;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 6px;
+}
+
+.heatmapTitle {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+  color: var(--text-secondary);
+}
+
+.heatmapSvgWrap {
   width: 100%;
-  padding: 4px 0;
-}
-
-.heatmapCol {
-  flex: 1;
-  min-width: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 3px;
-}
-
-.heatmapCell {
-  width: 100%;
-  aspect-ratio: 1 / 1;
-  border-radius: 2px;
-  cursor: default;
-}
-
-.heatmapCell:hover {
-  outline: 1px solid var(--text-secondary);
+  overflow: hidden;
 }
 
 .heatmapLegend {
   display: flex;
   align-items: center;
+  gap: 8px;
+}
+
+.legendItem {
+  display: flex;
+  align-items: center;
   gap: 3px;
-  margin-bottom: 8px;
-  justify-content: flex-end;
+  font-size: 10px;
+  color: var(--text-tertiary);
+}
+
+.legendRight {
+  font-size: 10px;
+  color: var(--text-tertiary);
+  margin-left: 4px;
 }
 


### PR DESCRIPTION
Replace oversized 7-row daily heatmap grid with a compact single-row SVG strip — one square per week, 52 weeks. Matches the Dashboard heatmap style and better represents the weekly heartbeat cadence.

## Changes
- `src/pages/Heartbeats.jsx` — replaced 7-row daily grid with 52-cell weekly strip
- `src/pages/Heartbeats.module.css` — compact styling for single-row layout

Closes no issue — visual polish.