### PR TITLE
fix: add build-prod script alias for DO buildpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "scripts": {
     "start": "export PORT=4001 && vite",
     "build": "vite build --mode production",
+    "build-prod": "vite build --mode production",
     "build:prod": "yarn codegen && vite build --mode production",
     "preview": "vite preview --port 4001",
     "prod": "npm run build && PORT=4001 serve -s build",


### PR DESCRIPTION
Adds `build-prod` script alias to `package.json` for DigitalOcean App Platform buildpack compatibility.

Commit: `99979ec`